### PR TITLE
Fix spelling errors.

### DIFF
--- a/docs/Personas-Account-Transfer-Fields.md
+++ b/docs/Personas-Account-Transfer-Fields.md
@@ -1,24 +1,24 @@
-#Persona Account Transfer
+# Persona Account Transfer
 
 To offer a reliable information, on each churn managing personas must update relevant nodes with appropriate account information. Following presents information required to be transferred on account transfer by managing personas.
 
 
-##Storage client manager
+## Storage client manager
 Storage client manager keeps records about the storage clients it is responsible for. The information kept represent the amount of network space the storage client is entitled to.
 
 | Storage client id | Available space | Stored space |
 | ------------------| --------------- | ------------ |
 
 
-##Data manager
+## Data manager
 Data manages holds account information about chunks it is responsible for. The account information for a chunk represent the chunk name and the id and status of nodes storing the chunk.
 
 | ChunkName | chunk size | `storage_node`s |
 | --------- | ---------- | --------------- |
 
-storage node info has id and the status (online / offline) for the node storing the chunk. We require 4 on line nodes and a max of 4 off line nodes. The off line is a FIFO queue and if any node is pushed off then its lost space is increased and stored is decreased. 
+storage node info has id and the status (online / offline) for the node storing the chunk. We require 4 on line nodes and a max of 4 off line nodes. The off line is a FIFO queue and if any node is pushed off then its lost space is increased and stored is decreased.
 
-##Storage node manager
+## Storage node manager
 
 Storage node manager holds account information about `storage nodes` it is responsible for. The account information for a storage node represent the id of the storage node along with store success/failure statistics related to that storage node.
 

--- a/docs/Personas-Account-Transfer-Fields.md
+++ b/docs/Personas-Account-Transfer-Fields.md
@@ -1,6 +1,6 @@
 #Persona Account Transfer
 
-To offer a reliable information, on each churn managing personas must update relevant nodes with appropraite account information. Following presents information required to be transferred on account transfer by managing personas.
+To offer a reliable information, on each churn managing personas must update relevant nodes with appropriate account information. Following presents information required to be transferred on account transfer by managing personas.
 
 
 ##Storage client manager
@@ -16,7 +16,7 @@ Data manages holds account information about chunks it is responsible for. The a
 | ChunkName | chunk size | `storage_node`s |
 | --------- | ---------- | --------------- |
 
-storage node info has id and the status (online / offline) for the node storing the chunck. We require 4 on line nodes and a max of 4 off line nodes. The off line is a FIFO queue and if any node is pushed off then its lost space is increased and stored is decreased. 
+storage node info has id and the status (online / offline) for the node storing the chunk. We require 4 on line nodes and a max of 4 off line nodes. The off line is a FIFO queue and if any node is pushed off then its lost space is increased and stored is decreased. 
 
 ##Storage node manager
 

--- a/docs/account_transfer.md
+++ b/docs/account_transfer.md
@@ -1,24 +1,24 @@
-#Account Transfer
+# Account Transfer
 
-##Introduction
+## Introduction
 
 The purpose of account transfer is to allow the network nodes to maintain the distributed state of the network. This state is held primarily as a key value store for various personas. As
 nodes go on and off line the network reconfigures around it and all state held in the group around the node has to be reconfigured. The current network implementation maintains 4 accurate
 copies of all state per address (address being a node or data element). To accurately manage 4 copies a network range for the 16 close nodes must be considered due to uni-directional
 closeness. This means that to ensure we have the 4 closest nodes we much consider at least 16 nodes surrounding any address.
 
-##Naming Conventions
+## Naming Conventions
 
 Proximity Group - the 16 nodes close to an address
 
 Close Group - the 4 nodes containing accurate information on any address.
 
 
-##Motivation
+## Motivation
 
 The motivation behind this design is to provide an efficient mechanism to transfer accounts data between nodes, whilst reusing as much of the existing design patterns as possible. As the values for all data for the various personas are potentially different then there is a lean towards forcing account data values to be synchronise-able. This really means the account value data should be consistent and not prone to any consensus. An example of bad values would be measurements that may vary across keys. These varying values must be at the very least minimised, or better removed. The current proposal is to allow account transfer to be as fast as possible and with minimum network traffic cost.
 
-##Overview
+## Overview
 
 Account transfer resembles network sync with a noticeable exception that there is at least one node less to consider. By definition a node has altered, by either disappearing or indeed possibly joining. So worst case scenario there will be a maximum of three other nodes with the info we require. An account transfer packet may be delivered to a node from another node in this proximity group of 16 at any time based on any churn at all in the proximity group.
 
@@ -28,7 +28,7 @@ In cases of conflict, which is determined to be the case where the consensus req
 
 The routing library will present an interface that allows upper layers to query any changes to the proximity group. This is defined in the section below.
 
-##Assumptions
+## Assumptions
 
 Routing will fire a signal of proximity group change. This will include an object (node_change or churn) that allows queries to be made on that change. This API will allow upper layers to query each state key they have and return an object that states the key/value should be either:
 
@@ -36,7 +36,7 @@ Routing will fire a signal of proximity group change. This will include an objec
 2. Sent on to at least 1 node (possibly more than 1)
 3. Left as is
 
-##Implementation
+## Implementation
 
 The implementation of the account transfer is presented in pseudo code below
 
@@ -94,6 +94,6 @@ void OnMessage::account_transfer_received(Message) {
 
  // Add in a mechanism to prune this list in a similar fashion to that which will be applied in routing firewall.
 ```
-The `OnMessage::Action routing::node_change(Record);` will return a value that triggers an action (such as delete, send to one/many, etc. or ignore) on adding to this map. It should be noted that account transfers could happen at any time for any node and any persona. 
+The `OnMessage::Action routing::node_change(Record);` will return a value that triggers an action (such as delete, send to one/many, etc. or ignore) on adding to this map. It should be noted that account transfers could happen at any time for any node and any persona.
 
 For integer based transfers where there may be slight differences in the integer values take the median value of the values obtained when the majority of transfers has been received.

--- a/docs/account_transfer.md
+++ b/docs/account_transfer.md
@@ -5,7 +5,7 @@
 The purpose of account transfer is to allow the network nodes to maintain the distributed state of the network. This state is held primarily as a key value store for various personas. As
 nodes go on and off line the network reconfigures around it and all state held in the group around the node has to be reconfigured. The current network implementation maintains 4 accurate
 copies of all state per address (address being a node or data element). To accurately manage 4 copies a network range for the 16 close nodes must be considered due to uni-directional
-closeness. This means that to ensure we have the 4 closest nodes we much consider at least 16 nodes surrounding any address. 
+closeness. This means that to ensure we have the 4 closest nodes we much consider at least 16 nodes surrounding any address.
 
 ##Naming Conventions
 
@@ -16,15 +16,15 @@ Close Group - the 4 nodes containing accurate information on any address.
 
 ##Motivation
 
-The motivation behind this design is to provide an efficient mechanism to transfer accounts data between nodes, whilst reusing as much of the existing design patterns as possible. As the values for all data for the various personas are potentially different then there is a lean towards forcing account data values to be synchronise-able. This really means the account value data should be consistent and not prone to any consensus. An example of bad values would be measurements that may vary across keys. These varying values must be at the very least minimised, or better removed. The current proposal is to allow account transfer to be as fast as possible and with minimum network traffic cost. 
+The motivation behind this design is to provide an efficient mechanism to transfer accounts data between nodes, whilst reusing as much of the existing design patterns as possible. As the values for all data for the various personas are potentially different then there is a lean towards forcing account data values to be synchronise-able. This really means the account value data should be consistent and not prone to any consensus. An example of bad values would be measurements that may vary across keys. These varying values must be at the very least minimised, or better removed. The current proposal is to allow account transfer to be as fast as possible and with minimum network traffic cost.
 
 ##Overview
 
 Account transfer resembles network sync with a noticeable exception that there is at least one node less to consider. By definition a node has altered, by either disappearing or indeed possibly joining. So worst case scenario there will be a maximum of three other nodes with the info we require. An account transfer packet may be delivered to a node from another node in this proximity group of 16 at any time based on any churn at all in the proximity group.
 
-The reason we always consider a node less is rather complex, but if a node 'moves in' to the group then one is pushed out, so why not use it's account? The reason is that as this change occurs we cannot know did the 5th node get a new message or the new node. To alleviate this concern there is a hard rule in place; if a node syncronises any action it writes it to the database. If a later account transfer happens on that key and there is already a record in the database, it's condered the latest as it happened via a sync message. If the new node missed the sync message the remaining threee should (may) have synced that action and will transfer it via an account transfer message, which will be written to the database. This rule covers a huge amount of edge cases, but may leave a very small amount of error in the account transfer. This error is aniticipated to be resolved in further account transfers where the error will be outvoted (so to speak) by the remaining correct values of the majority of the nodes. 
+The reason we always consider a node less is rather complex, but if a node 'moves in' to the group then one is pushed out, so why not use it's account? The reason is that as this change occurs we cannot know did the 5th node get a new message or the new node. To alleviate this concern there is a hard rule in place; if a node synchronises any action it writes it to the database. If a later account transfer happens on that key and there is already a record in the database, it's considered the latest as it happened via a sync message. If the new node missed the sync message the remaining three should (may) have synced that action and will transfer it via an account transfer message, which will be written to the database. This rule covers a huge amount of edge cases, but may leave a very small amount of error in the account transfer. This error is anticipated to be resolved in further account transfers where the error will be outvoted (so to speak) by the remaining correct values of the majority of the nodes.
 
-In cases of conflict, which is determined to be the case where the consensus reuqired is not achived, either through lack of copies or the copies not matching then the resolutions shall be; Send a synchronisation request on the key in question. i.e. if a key does reach consensus ie.the first X copes are all mathcing and X == min required match, then the key/value is accepted and written to the database if there is no key of that name already in place. 
+In cases of conflict, which is determined to be the case where the consensus required is not achieved, either through lack of copies or the copies not matching then the resolutions shall be; Send a synchronisation request on the key in question. i.e. if a key does reach consensus ie.the first X copes are all matching and X == min required match, then the key/value is accepted and written to the database if there is no key of that name already in place.
 
 The routing library will present an interface that allows upper layers to query any changes to the proximity group. This is defined in the section below.
 
@@ -51,9 +51,9 @@ Action routing::node_change(Record); or
 Action routing::node_change(Record::key);
 ```
 
-The action will determine whether to delete, send or ignore any action to be taken on this key. 
+The action will determine whether to delete, send or ignore any action to be taken on this key.
 
-Prior to calling this method in routing the node must provide a method similar to the accumulator in a normal message flow. This means that a vector or container similar will 'collect' account transfer messages and match them to call this method. 
+Prior to calling this method in routing the node must provide a method similar to the accumulator in a normal message flow. This means that a vector or container similar will 'collect' account transfer messages and match them to call this method.
 
 This takes the form
 ```
@@ -84,16 +84,16 @@ void OnMessage::account_transfer_received(Message) {
     if (count == (routing::parameters::close_group + 1) / 2)
 
      TryAddToDataBase(Message) // fail if already in database
-    
+
     if (count == routing::parameteres::close_group -1)
      messages_.erase(found); // all transferred now
   } else {
     messages_.push_back(Message);
   }
 }
- 
+
  // Add in a mechanism to prune this list in a similar fashion to that which will be applied in routing firewall.
 ```
-The `OnMessage::Action routing::node_change(Record);` will return a value that triggers an action (such as delete, send to one/many, etc. or ignore) on adding to this map. It shoud be noted that account transfers could happen at any time for any node and any persona. 
+The `OnMessage::Action routing::node_change(Record);` will return a value that triggers an action (such as delete, send to one/many, etc. or ignore) on adding to this map. It should be noted that account transfers could happen at any time for any node and any persona. 
 
 For integer based transfers where there may be slight differences in the integer values take the median value of the values obtained when the majority of transfers has been received.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -106,7 +106,7 @@ where the last flow deviates from the existing implementation, but would notify 
            e.g. MaidManagers{MaidNode}
 
 
-###Terms and conventions for individual documentation
+### Terms and conventions for individual documentation
 
 * ->> : represents a single to group message (no callback)
 * -> : represents a single to single message (no callback)
@@ -118,7 +118,7 @@ where the last flow deviates from the existing implementation, but would notify 
 * *=> : represents a group to single message (callback)
 * So - Send On, this function which sends the message on to the next persona is implicitly mentioned in all above notations. They can be explicitly mentioned, when it matters
 * Action.Sy : denotes synchronising the Action
-* Ac - Accumulate, This function accumulates messages from previous 
+* Ac - Accumulate, This function accumulates messages from previous
 * Fw - Firewall, this function ensures duplicate messages are prevented from progressing and answers such messages with the calculated response (such as success:error:synchronising etc. and may include a message containing data)
 * | : represents [Ac, FW]
 * [*Operation1*, *Operation2*, .. *OperationN*] : denotes sequential operations

--- a/docs/data_manager.md
+++ b/docs/data_manager.md
@@ -1,7 +1,7 @@
 #WIP - Do not use !!!
 #Introduction
 
-The `DataManager` [base type == `NaeManager`] is the persona that is responsible for data avalibility and integrity. To do so these personas must know where the data currently resides and the state of that data. This state is twofold, is the `Pmid Node` [base type ==`Node`] on-line and is the data itself intact and secure. The former is arguably the main issue as the data itself is self-validating (i.e. to construct an immutable chunk itself validates the content). To ensure this, a `DataManager` must know which nodes hold the data, and whether they are currently on or off line. These are currently the most data-heavy personas and under constant scrutiny to reduce the amount of data they hold.
+The `DataManager` [base type == `NaeManager`] is the persona that is responsible for data availability and integrity. To do so these personas must know where the data currently resides and the state of that data. This state is twofold, is the `Pmid Node` [base type ==`Node`] on-line and is the data itself intact and secure. The former is arguably the main issue as the data itself is self-validating (i.e. to construct an immutable chunk itself validates the content). To ensure this, a `DataManager` must know which nodes hold the data, and whether they are currently on or off line. These are currently the most data-heavy personas and under constant scrutiny to reduce the amount of data they hold.
 
 ##Motivation
 
@@ -16,19 +16,19 @@ The heart of the `DataManager` will be a mini SQL database. This will be managed
 | ChunkName | Version [0..3]| `PmidNodes`    |
 | --------- | --------------- | --------------|
 
-### Farming Rate 
+### Farming Rate
 
-There is also a `Farming Rate` held by each `DataManager` which controls the supply and demand of storage space. This number has a base value of `2^^10` at this time. This number must be investigated further as there is no scientific reason for this value of `2^^10`. This number is only a seed number though and will not appear in a live network afer the initial change. 
+There is also a `Farming Rate` held by each `DataManager` which controls the supply and demand of storage space. This number has a base value of `2^^10` at this time. This number must be investigated further as there is no scientific reason for this value of `2^^10`. This number is only a seed number though and will not appear in a live network afer the initial change.
 
-This rate alters as the network dynamic alters and does so in this manner. 
+This rate alters as the network dynamic alters and does so in this manner.
 
 1. As a store is attempted for a third copy (version 2)
-  
-  a. If atempt fails then farming rate is halved (shift right 1 bit) from it's current value.
-  
+
+  a. If attempt fails then farming rate is halved (shift right 1 bit) from it's current value.
+
   b. If attempt succeeds farming rate is doubled (shift left 1 bit) from it's current value **only** when all failed 3rd copies have been sucessfully stored again. If there are no currently failed stores the farming rate is not altered.
 
 Each ChunkName will have a list of associated `PmidNodes`s. The on-/off-line status of these nodes is held in the routing table of the `DataManager` already and need not be replicated in the database.
 
-On a churn event, the SQL database should be searched for every chunk that old node had and joined with what chunks the new nodes has. Any chunk with less than two holders should now be stored to the node closest to the chunk name. 
+On a churn event, the SQL database should be searched for every chunk that old node had and joined with what chunks the new nodes has. Any chunk with less than two holders should now be stored to the node closest to the chunk name.
 Records of nodes holding a chunk should be held in a manner so that as a new node comes on line, it is put to the top of the list.

--- a/docs/data_manager.md
+++ b/docs/data_manager.md
@@ -5,7 +5,7 @@ The `DataManager` [base type == `NaeManager`] is the persona that is responsible
 
 ## Motivation
 
-Unlike the other personas the data manager has currently no easy win in terms of reducing the amount of information the persona holds. There is a very valid opportunity though via a better holding mechnaism (via sqlite) and also the length of the keys held. So there are two factors involved in this case: more efficient engine for managing the data and also the size of the data we are managing.
+Unlike the other personas the data manager has currently no easy win in terms of reducing the amount of information the persona holds. There is a very valid opportunity though via a better holding mechanism (via sqlite) and also the length of the keys held. So there are two factors involved in this case: more efficient engine for managing the data and also the size of the data we are managing.
 
 In the SAFE network there are three `DataManager` groups per chunk and each group will ensure two copies are stored. These groups are deterministic and are either group zero (where hash of content == name) or group 1 (where hash(hash of content) == name, or group 3 where hash(hash(hash of content)) == name).
 
@@ -18,7 +18,7 @@ The heart of the `DataManager` will be a mini SQL database. This will be managed
 
 ### Farming Rate
 
-There is also a `Farming Rate` held by each `DataManager` which controls the supply and demand of storage space. This number has a base value of `2^^10` at this time. This number must be investigated further as there is no scientific reason for this value of `2^^10`. This number is only a seed number though and will not appear in a live network afer the initial change.
+There is also a `Farming Rate` held by each `DataManager` which controls the supply and demand of storage space. This number has a base value of `2^^10` at this time. This number must be investigated further as there is no scientific reason for this value of `2^^10`. This number is only a seed number though and will not appear in a live network after the initial change.
 
 This rate alters as the network dynamic alters and does so in this manner.
 
@@ -26,7 +26,7 @@ This rate alters as the network dynamic alters and does so in this manner.
 
   a. If attempt fails then farming rate is halved (shift right 1 bit) from it's current value.
 
-  b. If attempt succeeds farming rate is doubled (shift left 1 bit) from it's current value **only** when all failed 3rd copies have been sucessfully stored again. If there are no currently failed stores the farming rate is not altered.
+  b. If attempt succeeds farming rate is doubled (shift left 1 bit) from it's current value **only** when all failed 3rd copies have been successfully stored again. If there are no currently failed stores the farming rate is not altered.
 
 Each ChunkName will have a list of associated `PmidNodes`s. The on-/off-line status of these nodes is held in the routing table of the `DataManager` already and need not be replicated in the database.
 

--- a/docs/data_manager.md
+++ b/docs/data_manager.md
@@ -1,15 +1,15 @@
-#WIP - Do not use !!!
-#Introduction
+# WIP - Do not use !!!
+# Introduction
 
 The `DataManager` [base type == `NaeManager`] is the persona that is responsible for data availability and integrity. To do so these personas must know where the data currently resides and the state of that data. This state is twofold, is the `Pmid Node` [base type ==`Node`] on-line and is the data itself intact and secure. The former is arguably the main issue as the data itself is self-validating (i.e. to construct an immutable chunk itself validates the content). To ensure this, a `DataManager` must know which nodes hold the data, and whether they are currently on or off line. These are currently the most data-heavy personas and under constant scrutiny to reduce the amount of data they hold.
 
-##Motivation
+## Motivation
 
 Unlike the other personas the data manager has currently no easy win in terms of reducing the amount of information the persona holds. There is a very valid opportunity though via a better holding mechnaism (via sqlite) and also the length of the keys held. So there are two factors involved in this case: more efficient engine for managing the data and also the size of the data we are managing.
 
 In the SAFE network there are three `DataManager` groups per chunk and each group will ensure two copies are stored. These groups are deterministic and are either group zero (where hash of content == name) or group 1 (where hash(hash of content) == name, or group 3 where hash(hash(hash of content)) == name).
 
-##Overview
+## Overview
 
 The heart of the `DataManager` will be a mini SQL database. This will be managed via sqlite3. The table structure will be very simple.
 

--- a/docs/data_manager_account.md
+++ b/docs/data_manager_account.md
@@ -1,21 +1,21 @@
-#Data Manager account
+# Data Manager account
 
-##Updated Naming Conventions
+## Updated Naming Conventions
 
 - MaidClient is now referred to as `storage_client`
 - MaidManager is now referred to as `storage_client_manager`
 - PmidNode is now referred to as `storage_node`
 - PmidManager is now referred to as `storage_node_manager`
 
-##Introduction
+## Introduction
 
 The `data_manager` is the persona that is responsible for data avalibility and integrity. To do so these personas must know where the data currently resides and the state of that data. This state is twofold, is the `storage_node` on-line and is the data itself intact and secure. The former is arguably the main issue as the data itself is self-validating (i.e. to construct an immutable chunk itself validates the content). To ensure this, a `data_manager` must know which nodes hold the data, and whether they are currently on or off line. These are currently the most data-heavy personas and under constant scrutiny to reduce the amount of data they hold.
 
-##Motivation
+## Motivation
 
 The main motiviation for re-factoring this persona is efficiency: unlike the other personas the data manager has currently no easy win in terms of reducing the amount of information the persona holds. There is a very valid opportunity though via a better holding mechnaism (via sqlite) and also the length of the keys held. So there are two factors involved in this case: more efficient engine for managing the data and also the size of the data we are managing.
 
-##Overview
+## Overview
 
 The heart of the `data_manager` will be a mini SQL database. This will be managed via sqlite3. The table structure will be very simple.
 
@@ -29,4 +29,4 @@ On a churn event, the SQL database should be searched for every chunk that old n
 Records of nodes holding a chunk should be held in a manner so that as a new node comes on line, it is put to the top of the list.
 
 
-##Implementation
+## Implementation

--- a/docs/data_manager_account.md
+++ b/docs/data_manager_account.md
@@ -13,7 +13,7 @@ The `data_manager` is the persona that is responsible for data avalibility and i
 
 ## Motivation
 
-The main motiviation for re-factoring this persona is efficiency: unlike the other personas the data manager has currently no easy win in terms of reducing the amount of information the persona holds. There is a very valid opportunity though via a better holding mechnaism (via sqlite) and also the length of the keys held. So there are two factors involved in this case: more efficient engine for managing the data and also the size of the data we are managing.
+The main motiviation for re-factoring this persona is efficiency: unlike the other personas the data manager has currently no easy win in terms of reducing the amount of information the persona holds. There is a very valid opportunity though via a better holding mechanism (via sqlite) and also the length of the keys held. So there are two factors involved in this case: more efficient engine for managing the data and also the size of the data we are managing.
 
 ## Overview
 

--- a/docs/get_flow.md
+++ b/docs/get_flow.md
@@ -1,6 +1,6 @@
 # Workflow for getting data from Vault Network
 Client send get requests to network which will be handled by NAE(DataManager) first.
-Attempts to fectch Backup and Sacrificial copies will be carried by client at the same time.
+Attempts to fetch Backup and Sacrificial copies will be carried by client at the same time.
 i.e. there will be three get requests fired to network at the same time,
      and DMs around data_name(Hash(data)) for Primary copy, Hash(data_name) for Backup copy,
          and Hash(Hash(data_name)) for Sacrificial copy will be queried at the same time.

--- a/docs/get_flow.md
+++ b/docs/get_flow.md
@@ -10,7 +10,7 @@ TODO: it is optional the replied data being sent to DMs as well so that they can
 If there is no data stored, it will reply with an error (routing ensures the failure response being sent back to the DMs, which will update its record to remove this pmid_node as holder.)
 
 
-###Get(N)
+### Get(N)
 _Client_  *->> |__DataManager__  (Primary, Backup, Sacrificial) [Exist(name) ? So : Terminate_Flow]
           *->  |_PmidNode_ [Has(name) ? Reply(data) : GetFailure]
 
@@ -19,7 +19,7 @@ Note : name is N which is Hash(D) for Primary copy, is Hash(N) for Backup copy a
 
 
 --
-#####PmidNode::PutFailure
+##### PmidNode::PutFailure
 _PmidNode_ ->> |__DataManager__ { [Value.Pmids.Count <= Threshold ? Replicate(D) ],
                                   RemovePmid.Sy,
                                   [[LyingPmidNode ? CorrectionToPmidManager.So], DownRank(PN)] }
@@ -27,5 +27,5 @@ _PmidNode_ ->> |__DataManager__ { [Value.Pmids.Count <= Threshold ? Replicate(D)
 
 --
 <dd>Description: Get D from TempStore or network, then PutRequest(D).</ddt>
-#####DataManager::Replicate
+##### DataManager::Replicate
 __DataManager__ ([!TempStoreHas(D) ? NetworkGet(D)])(PutRequest.So(D))

--- a/docs/maid_account.md
+++ b/docs/maid_account.md
@@ -1,25 +1,25 @@
-#MAID (client anonymous store/get data) account
+# MAID (client anonymous store/get data) account
 
-##Naming Conventions
+## Naming Conventions
 
 MaidClient  -> is now referred to as ```storage_client```
 MaidManager -> is now referred to as ```storage_client_manager```
 
-##Introduction
+## Introduction
 
 The ```storage_client``` is a 2nd degree key pair, it's is signed by the pure keypair referred to a ANMAID (Anonmous). This identity is not published and does not require to be published. It is an anoymous identity used purely for put/get/delete (later) data onto the network. This is data and not communications, safecoin, computing etc. it is only data (immutable and mutable) data for private, public and private shared files. The account is held in the close group this ID connect to and is referred to as the ```storage_client_manager```group.
 
 The account information will allow the network to measure data stored and available. This allows users of the system to interact with the network in terms of data storing.
 
 
-##Motivation
+## Motivation
 
 To allow the network to expand at the fastest rate then as many nodes as possible need to be considered as routing nodes. At the moment this is not possible, due to the size of account information. The ```storage_client``` has been a huge amount of data, to allow deletes to be counted and reduce storage. With safecoin this delete was abandoned and the likelihood of the ```storage_client``` account being removed was considered. This is not a good mechnaism as people can abuse the network, unless a measure is in place. Therefor an account is required, but it must be minimal.
 
 As all the machinery is in place to link accounts to vaults then there is a quick win. To allow actual storage measurements though, the delete issue is still relevant, how can we know a delete is allowed unless we know the corresponding PUT took place? The answer to that will be another design document, it's as simple as removing duplicate private data and make all data unique and signed. A signature to delete will allow reduction in storage for the client. This is considered later though and mentioned here for clarity.
 
 
-##Overview
+## Overview
 
 The ```storage_client``` account information can be split into two integers (64 bit). These are :
 ```Data Stored```
@@ -31,4 +31,4 @@ These two integers are updated as so:
 
 2. Space available is dependent on the number of safecoin used to purchase space. The mechanism to get safecoin or to calculate the space per coin is not part of this document. The ability to record a safecoin and be awarded space is though. This should be set at 1 safecoin per gB for now, this is a test figure and will be adjusted in the design doc for that coin. Initially we assume everyone has a safecoin in arrears limit (i.e. a free Gb)
 
-##Implementation
+## Implementation

--- a/docs/maid_account.md
+++ b/docs/maid_account.md
@@ -2,21 +2,21 @@
 
 ##Naming Conventions
 
-MaidClient  -> is now referred to as ```storage_client``` 
+MaidClient  -> is now referred to as ```storage_client```
 MaidManager -> is now referred to as ```storage_client_manager```
 
 ##Introduction
 
 The ```storage_client``` is a 2nd degree key pair, it's is signed by the pure keypair referred to a ANMAID (Anonmous). This identity is not published and does not require to be published. It is an anoymous identity used purely for put/get/delete (later) data onto the network. This is data and not communications, safecoin, computing etc. it is only data (immutable and mutable) data for private, public and private shared files. The account is held in the close group this ID connect to and is referred to as the ```storage_client_manager```group.
 
-The account information will allow the network to measure data stored and available. This allows users of the system to interact with the network in terms of data storing. 
+The account information will allow the network to measure data stored and available. This allows users of the system to interact with the network in terms of data storing.
 
 
 ##Motivation
 
-To allow the network to expand at the fastest rate then as many nodes as possible need to be considered as routing nodes. At the moment this is not possible, due to the size of account information. The ```storage_client``` has been a huge amount of data, to allow deletes to be counted and reduce storage. With safecoin this delete was abandoned and the likelyhood of the ```storage_client``` account being removed was considered. This is not a good mechnaism as people can abuse the network, unless a measure is in place. Therefor an account is required, but it must be minimal. 
+To allow the network to expand at the fastest rate then as many nodes as possible need to be considered as routing nodes. At the moment this is not possible, due to the size of account information. The ```storage_client``` has been a huge amount of data, to allow deletes to be counted and reduce storage. With safecoin this delete was abandoned and the likelihood of the ```storage_client``` account being removed was considered. This is not a good mechnaism as people can abuse the network, unless a measure is in place. Therefor an account is required, but it must be minimal.
 
-As all the machinery is in place to link accounts to vaults then there is a quick win. To allow actual storage measurements though, the delete issue is still relevent, how can we know a delete is allowed unless we know the correspongin PUT took place? The answer to that will be another design document, it's as simple as removing duplicate private data and make all data unique and signed. A signature to delete will allow reduction in storage for the client. This is considered later though and mentioned here for clarity. 
+As all the machinery is in place to link accounts to vaults then there is a quick win. To allow actual storage measurements though, the delete issue is still relevant, how can we know a delete is allowed unless we know the corresponding PUT took place? The answer to that will be another design document, it's as simple as removing duplicate private data and make all data unique and signed. A signature to delete will allow reduction in storage for the client. This is considered later though and mentioned here for clarity.
 
 
 ##Overview
@@ -25,11 +25,10 @@ The ```storage_client``` account information can be split into two integers (64 
 ```Data Stored```
 ```Space Available```
 
-These two itegers are updated as so:
+These two integers are updated as so:
 
 1. On storing any data, the stored value is incremented with the size stored. This data is syncronised amongst the group (as is already) and account transferred as per todays design. (deletes are a later design, this is increment only at the moment)
 
-2. Space available is dependent on the number of safecoin used to purchase space. The mechanism to get safecoin or to calculate the space per coin is not part of this document. The ability to record a safecoin and be awarded space is though. This should be set at 1 safecoin per gB for now, this is a test figure and will be adjusted in the design doc for that coin. Initially we assume everyone has a safecoin in arrears limit (i.e. a free Gb) 
+2. Space available is dependent on the number of safecoin used to purchase space. The mechanism to get safecoin or to calculate the space per coin is not part of this document. The ability to record a safecoin and be awarded space is though. This should be set at 1 safecoin per gB for now, this is a test figure and will be adjusted in the design doc for that coin. Initially we assume everyone has a safecoin in arrears limit (i.e. a free Gb)
 
 ##Implementation
-

--- a/docs/mpid_messaging.md
+++ b/docs/mpid_messaging.md
@@ -6,28 +6,28 @@ Design document 1.0
 Introduction
 ============
 
-In MaidSafe the ability for secured messaging is obvious and may take many forms, mail like, IM like etc. This document outlines the system componenets and design for general communications infrastructure and security. 
+In MaidSafe the ability for secured messaging is obvious and may take many forms, mail like, IM like etc. This document outlines the system components and design for general communications infrastructure and security. 
 
 Motivation
 ==========
 
 The motivation for a messaging system is an obvious one, but a wider motivation is, as always in MaidSafe, a messaging system that is secure and private without the possibility of snooping tracking or being abused in any way. A large abuse of modern day digital communications is the ability for immoral entities such as spammers and the less than ethical marketing companies to flood the Internet with levels of unsolicited email to a level of circa 90%. This is a waste of good bandwidth and also a nuisance of significant proportions.
 
-A MaidSafe messaging system will attempt to eradicate unwanted and intrusive communications. This would seem counter intuative to a network that purports to be more efficient, cheaper and faster than today's mechanisms. The flip side of this is the network's ability to work autonomously and follow pre-programmed rules. With such rules then the network can take care of people's inboxes and outboxes for incoming and outgoing mail respectively. 
+A MaidSafe messaging system will attempt to eradicate unwanted and intrusive communications. This would seem counter-intuative to a network that purports to be more efficient, cheaper and faster than today's mechanisms. The flip side of this is the network's ability to work autonomously and follow pre-programmed rules. With such rules then the network can take care of people's inboxes and outboxes for incoming and outgoing mail respectively.
 
-This design outlines a mechanism where the cost of messaging is with the sender as this would seem more natural. To achieve this, the sender will maintain messages in the network outbox until they are retrived by the recipient. If the email is unwanted the recipient simply does not retrieve the message. The sender will quickly fill their own outbox with undelivered mail and be forced to clean this up, themselves.
+This design outlines a mechanism where the cost of messaging is with the sender as this would seem more natural. To achieve this, the sender will maintain messages in the network outbox until they are retrieved by the recipient. If the email is unwanted the recipient simply does not retrieve the message. The sender will quickly fill their own outbox with undelivered mail and be forced to clean this up, themselves.
 
 This paradigm shift will mean that the obligation to un-subscribe from mailing lists etc. is now with the owner of these lists. If people are not picking up mail, it is because they do not want it. So the sender has to do a better job. It is assumed this shift of responsibilities will lead to a better managed bandwidth solution and considerably less stress on the network and the users of the network.
 
 Overview
 ========
 
-A good way to look at the solution is that, rather than charging for unwanted mail with cash, the network charges with a limited resource and then prevents further abuse. In another apsect this is regulation of entities by the users of the system affected by that entity. Rather than build a ranking system to prevent bad behaviour, this proposal is actually the affected people acting independently. This protects the minorites who may suffer from system wide rules laid down by any designer of such rules. 
+A good way to look at the solution is that, rather than charging for unwanted mail with cash, the network charges with a limited resource and then prevents further abuse. In another aspect this is regulation of entities by the users of the system affected by that entity. Rather than build a ranking system to prevent bad behaviour, this proposal is actually the affected people acting independently. This protects the minorities who may suffer from system wide rules laid down by any designer of such rules.
 
 Network OutBox
 --------------
 
-This is a simple data structure for now and will be a ```std::map``` ordered by the hash of the serialised and encrypted ```MpidMessage```  and with a user defined object to represent the message (value). The map will be named with the ID of the MPID it represents (owner). The data structure for the value will be 
+This is a simple data structure for now and will be a ```std::map``` ordered by the hash of the serialised and encrypted ```MpidMessage```  and with a user defined object to represent the message (value). The map will be named with the ID of the MPID it represents (owner). The data structure for the value will be
 
 ```c++
 struct MpidMessage {
@@ -66,10 +66,10 @@ Mpid (A) -> - *                                    * - <-Mpid (B)
 1. The user at Mpid(A) sends MpidMessage to MpidManager(A) signed with the recipient included
 2. The MpidManagers(A) sync this message and perform the action() which sends the MpidAlert to MpidManagers(B) [the ```MpidAlert::message_id``` at this stage is hash of the MpidMessage.
 3. MpidManager(B) stores the MpidAlert and sends the alert to Mpid(B) as soon as it is found online.
-4. On receving the alert, Mpid(B) sends a ```retrieve_message``` to MpidManagers(B) which is forwarded to MpidManagers(A).
+4. On receiving the alert, Mpid(B) sends a ```retrieve_message``` to MpidManagers(B) which is forwarded to MpidManagers(A).
 5. MpidManagers(A) sends the message to MpidManagers(B) which is forwarded to MPid(B) if MPid(B) is online.
-6. On receiving the message, Mpid(B) sends a remove request to MpidManagers(B), MpidManagers(B) sync remove the corresponding alert and forward the remove request to MpidManager(A). MpidManagers(A) sync remove the corresponding entry. 
-7. When Mpid(A) decides to remove the MpidMessage from the OutBox, if the message hasn't been retrived by Mpid(B) yet. The MpidManagers(A) group should not only remove the correspondent MpidMessage from their OutBox of Mpid(A), but also send a notification to the group of MpidManagers(B) so they can remove the correspodent MpidAlert from their InBox of Mpid(B).
+6. On receiving the message, Mpid(B) sends a remove request to MpidManagers(B), MpidManagers(B) sync remove the corresponding alert and forward the remove request to MpidManager(A). MpidManagers(A) sync remove the corresponding entry.
+7. When Mpid(A) decides to remove the MpidMessage from the OutBox, if the message hasn't been retrieved by Mpid(B) yet. The MpidManagers(A) group should not only remove the correspondent MpidMessage from their OutBox of Mpid(A), but also send a notification to the group of MpidManagers(B) so they can remove the correspondent MpidAlert from their InBox of Mpid(B).
 
 _MPid(A)_ =>> |__MPidManager(A)__ (Put.Sync)(Alert.So) *->> | __MPidManager(B)__  (Store(Alert).Sync)(Online(Mpid(B)) ? Alert.So : (WaitForOnlineB)(Alert.So)) *-> | _Mpid(B)_ So.Retreive ->> | __MpidManager(B)__ *-> | __MpidManager(A)__ So.Message *->> | __MpidManager(B)__ Online(Mpid(B)) ? Message.So *-> | _Mpid(B)_ Remove.So ->> | __MpidManager(B)__ {Remove(Alert).Sync, Remove.So} *->> | __MpidManager(A)__ Remove.Sync
 
@@ -80,11 +80,11 @@ The messaging client, as described as Mpid(X) in the above section, can be named
 1. Send Message (Put from sender)
 2. Retrieve Full Message (Get from receiver)
 3. Remove sent Message (Delete from sender)
-4. Accept Message Alert (when ```PUSH``` model used) and/or Retrive Message Alert (when ```PULL``` model used)
+4. Accept Message Alert (when ```PUSH``` model used) and/or Retrieve Message Alert (when ```PULL``` model used)
 
 When ```PUSH``` model is used, nfs_mpid_client is expected to have it's own routing object (not sharing with maid_nfs). So it can connect to network directly allowing the MpidManagers around it to tell the connection status directly.
 
-Such seperate routing object is not required when ```PULL``` model is used. It may also have the benefit of saving the battery life on mobile device as the client app doesn't need to keeps nfs_mpid_client running all the time.
+Such separate routing object is not required when ```PULL``` model is used. It may also have the benefit of saving the battery life on mobile device as the client app doesn't need to keeps nfs_mpid_client running all the time.
 
 Network Language
 ============
@@ -101,4 +101,4 @@ _MPid(A)_ =>> | __MPidManager(A)__  (Put)(Alert.So)
 Future Works
 ============
 
-This proposal implements a container as a std::map, it is assumed this will fall over to become a Structured Data Version ([SDV](https://github.com/maidsafe/MaidSafe-Common/blob/next/include/maidsafe/common/data_types/structured_data_versions.h)) when/if SDV is able to insert/delete single elements in a branch (possibly doubly linked list type). This is considered premature optimisation at this stage of development and requires measuring of the performance/size hit on adding two pointers per node. 
+This proposal implements a container as a std::map, it is assumed this will fall over to become a Structured Data Version ([SDV](https://github.com/maidsafe/MaidSafe-Common/blob/next/include/maidsafe/common/data_types/structured_data_versions.h)) when/if SDV is able to insert/delete single elements in a branch (possibly doubly linked list type). This is considered premature optimisation at this stage of development and requires measuring of the performance/size hit on adding two pointers per node.

--- a/docs/post_flow.md
+++ b/docs/post_flow.md
@@ -12,8 +12,8 @@ Client later on can send post request to network which will be handled by the Ve
 If the client proved to be the owner of that versionable data, VersionHandlers will update it.
 There will be no response being sent back no matter such update is succeed or fail.
 
-###Put(VD)
+### Put(VD)
 _Client_  *->> |__VersionHanlder__  [Exist(VD) ? Terminate_Flow : Register(VD)]
 
-###Post(VD_name, newV)
+### Post(VD_name, newV)
 _Client_  *->> |__VersionHanlder__  [Exist(VD_name) ? Update(VD_name, newV) : Terminate_Flow]

--- a/docs/post_flow.md
+++ b/docs/post_flow.md
@@ -2,7 +2,7 @@
 In vault network, "posting" means data manipulation, i.e. allows data to be updated by the data owner.
 Some assumptions are made here :
     1, The data type is versionable(i.e. manipulatable), currently there is only StructuredData has been defined
-    2, The original copy of such data must be put to the network from client directly to VersionaHandler
+    2, The original copy of such data must be put to the network from client directly to VersionHandler
     3, The data copy that new version pointing to has been uploaded to the network following the normal put flow.
 
 Client first send a put request to network with the original copy versionable data (StructuredData).
@@ -17,4 +17,3 @@ _Client_  *->> |__VersionHanlder__  [Exist(VD) ? Terminate_Flow : Register(VD)]
 
 ###Post(VD_name, newV)
 _Client_  *->> |__VersionHanlder__  [Exist(VD_name) ? Update(VD_name, newV) : Terminate_Flow]
-

--- a/docs/put_flow.md
+++ b/docs/put_flow.md
@@ -8,7 +8,7 @@ When PmidNode doesn't have enough space to store the copy, it will try to remove
 For each removed Sacrificial copy, a PutFailure will be sent out from PmidNode to PmidManager then to DataManager to ensure each persona get proper informed.
 
 
-###Put(D)
+### Put(D)
 _Client_   =>> |__ClientManager__ (Primary, Backup, Sacrificial)[Allow ? So : PutFailure]
           *->> |__DataManager__  [Exist(D) ? Terminate_Flow : {AddPmid.Sy, So}]
           *->> |__PmidManager__ {Put.Sy, So}
@@ -20,11 +20,11 @@ i.e. requiring a hash verification process in DataManager and PmidNode to replac
 Note : an active discussion remains whether Put flow needs to Reply on success.
 
 --
-#####MaidManager::PutFailure
+##### MaidManager::PutFailure
 __ClientManager__ *-> |_Client_
 
 --
-#####PmidNode::PutFailure
+##### PmidNode::PutFailure
 _PmidNode_ ->> |__PmidManager__ {Delete.Sy, So}
           *->> |__DataManager__ { [Value.Pmids.Count <= Threshold ? Replicate(D) ],
                                   RemovePmid.Sy,
@@ -32,7 +32,7 @@ _PmidNode_ ->> |__PmidManager__ {Delete.Sy, So}
 
 --
 <dd>Try to remove Sacrificial data to empty space</ddt>
-#####PmidNode::TryToRemoveSacrificial
+##### PmidNode::TryToRemoveSacrificial
 __PmidNode__ { [PutFailure(RemoveSacrificial(D))], [Store ? Flow_Completed : PutFailure] }
 
 Note: for each removed Sacrificial data, a PutFailure will be sent out
@@ -40,5 +40,5 @@ Note - patch: Routing will interpret here that a FailureToStoreData with differe
 
 --
 <dd>Description: Get D from TempStore or network, then PutRequest(D).</ddt>
-#####DataManager::Replicate
+##### DataManager::Replicate
 __DataManager__ ([!TempStoreHas(D) ? NetworkGet(D)])(PutRequest.So(D))

--- a/docs/safecoin_farming_rate.md
+++ b/docs/safecoin_farming_rate.md
@@ -2,34 +2,33 @@
 
 ## Introduction
 
-The farming rate is a mechanism to allow the network to balance supply and demand of the network cpabilities. This includes primarily storage, but takes into account bandwidth, cpu and any other resources involved in the management of network data. To achieve this the network requires to know when there is too much, just enough or too little resources.
+The farming rate is a mechanism to allow the network to balance supply and demand of the network capabilities. This includes primarily storage, but takes into account bandwidth, cpu and any other resources involved in the management of network data. To achieve this the network requires to know when there is too much, just enough or too little resources.
 
 ## DataManager groups
 
-A DataManager is a specialisation of a NaeManager. It has the responsibility of storing data and ensuring it's integrity. Each DM group will monitor 2 copies of each ImmutableData type. There is a primary DM group, a backup DM group and sacrifical DM group for the three types created for every ImmutabelData packet.
+A DataManager is a specialisation of a NaeManager. It has the responsibility of storing data and ensuring it's integrity. Each DM group will monitor 2 copies of each ImmutableData type. There is a primary DM group, a backup DM group and sacrificial DM group for the three types created for every ImmutableData packet.
 
-## Data types. 
+## Data types.
 
 ImmutableData has three types, these are ImmutableData, ImmutableDataBackup & ImmutableDataSacrificial. These types all contain the same data (see [types lib](https://github.com/maidsafe/maidsafe_types)) and are monitored by the DataManagers.
 
-##Sacrifical copies 
+##Sacrifical copies
 
-The third data type ImmutableDataSacrificial which is the network measuring stick. These types are only attempted to be stored, whereas other types MUST be stored. In the case where other types cannot be stored then copies of Sacrifical data will be deleted from the PMID nodes, and a notification will be sent from pmid_node back to PmidManager then eventually reach DataManager (see [put_flow](https://github.com/maidsafe/maidsafe_vault/blob/master/docs/put_flow.md) and check put_response part for detail). 
+The third data type ImmutableDataSacrificial which is the network measuring stick. These types are only attempted to be stored, whereas other types MUST be stored. In the case where other types cannot be stored then copies of Sacrificial data will be deleted from the PMID nodes, and a notification will be sent from pmid_node back to PmidManager then eventually reach DataManager (see [put_flow](https://github.com/maidsafe/maidsafe_vault/blob/master/docs/put_flow.md) and check put_response part for detail).
 
 ##Farming Rate
-This rate calculation is a simple approach and meant as a tool to investigate the algorithm. A simple add/subtract mechnism is in place to allow measurement. This is not intended for production and will undergo vigerous proofs (which are not complex, but need to be linked to cost of storage from client side)
+This rate calculation is a simple approach and meant as a tool to investigate the algorithm. A simple add/subtract mechanism is in place to allow measurement. This is not intended for production and will undergo vigorous proofs (which are not complex, but need to be linked to cost of storage from client side)
 
-The initial Farming rate mechnism is as follows:
+The initial Farming rate mechanism is as follows:
 
 1. Start at FM == 1
-2. For every Sacrifical data store (both copies) the rate increases by 1.
-3. For every Sacrifical data unable to be stored (or indeed deleted) the farming rate shall drop by 1. 
+2. For every Sacrificial data store (both copies) the rate increases by 1.
+3. For every Sacrificial data unable to be stored (or indeed deleted) the farming rate shall drop by 1.
 
 [It is very likely this rate will exponentially increase and linearly drop after measurements]
 
-Vaults will keep a placeholder and on churn attempt to store Sacrifical data lost by requestiong copies of the backup immutable data, this happens until we get back to a position of full nodes again. 
+Vaults will keep a placeholder and on churn attempt to store Sacrificial data lost by requesting copies of the backup immutable data, this happens until we get back to a position of full nodes again.
 
-## Accounting 
+## Accounting
 
 The Farming rate is held by all DM in a group, on a churn event this specific account info is transferred as a refresh command. The account type is orderable and the routing sentinel will get the median value to return back to vaults.
-

--- a/docs/safecoin_farming_rate.md
+++ b/docs/safecoin_farming_rate.md
@@ -12,11 +12,11 @@ A DataManager is a specialisation of a NaeManager. It has the responsibility of 
 
 ImmutableData has three types, these are ImmutableData, ImmutableDataBackup & ImmutableDataSacrificial. These types all contain the same data (see [types lib](https://github.com/maidsafe/maidsafe_types)) and are monitored by the DataManagers.
 
-##Sacrifical copies
+## Sacrifical copies
 
 The third data type ImmutableDataSacrificial which is the network measuring stick. These types are only attempted to be stored, whereas other types MUST be stored. In the case where other types cannot be stored then copies of Sacrificial data will be deleted from the PMID nodes, and a notification will be sent from pmid_node back to PmidManager then eventually reach DataManager (see [put_flow](https://github.com/maidsafe/maidsafe_vault/blob/master/docs/put_flow.md) and check put_response part for detail).
 
-##Farming Rate
+## Farming Rate
 This rate calculation is a simple approach and meant as a tool to investigate the algorithm. A simple add/subtract mechanism is in place to allow measurement. This is not intended for production and will undergo vigorous proofs (which are not complex, but need to be linked to cost of storage from client side)
 
 The initial Farming rate mechanism is as follows:


### PR DESCRIPTION
This pull request fixes various spelling errors in the documentation and standardises the markdown format with GitHub's markdown cheatsheet.

https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/maidsafe_vault/146)
<!-- Reviewable:end -->
